### PR TITLE
webcomponents-lite.js instead of the min version

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -84,7 +84,7 @@
 
         if (!webComponentsSupported) {
           var script = document.createElement('script');
-          script.src = '/bower_components/webcomponentsjs/webcomponents-lite.min.js';
+          script.src = '/bower_components/webcomponentsjs/webcomponents-lite.js';
           script.onload = onload;
           document.head.appendChild(script);
         } else {

--- a/polymer.json
+++ b/polymer.json
@@ -22,6 +22,6 @@
   ],
   "includeDependencies": [
     "manifest.json",
-  	"bower_components/webcomponentsjs/webcomponents-lite.min.js"
+  	"bower_components/webcomponentsjs/webcomponents-lite.js"
   ]
 }


### PR DESCRIPTION
min version doens’t allow for queryselecting